### PR TITLE
Fixes typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ EXTRA_CHECKS = {
 - **field-text-null** - text fields shoudn't use `null=True`.
 - **field-boolean-null** - prefer using `BooleanField(null=True)` instead of `NullBooleanField`.
 - **field-null** - don't pass `null=False` to model fields (this is django default).
-- **field-foreign-key-index** - ForeignKey fields must specify `db_index` explicitly (to apply only to fields in indexes: `when: indexes`).
+- **field-foreign-key-db-index** - ForeignKey fields must specify `db_index` explicitly (to apply only to fields in indexes: `when: indexes`).
 - **field-default-null** - If field nullable (`null=True`), then
     `default=None` argument is redundant and should be removed.
     **WARNING** Be aware that setting is database dependent,


### PR DESCRIPTION
Your actual code uses another name: https://github.com/kalekseev/django-extra-checks/blob/master/src/extra_checks/check_id.py#L19

I was getting:

```
CRITICALS:
?: (X001) Invalid EXTRA_CHECKS config. [extra-checks-config]
        HINT: Fix EXTRA_CHECKS in your settings. Errors:
* checks
  * ID field-foreign-key-index is not one of the available checks.
```