### PR TITLE
fix: field-choices-constraint on nullable IntegerField 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ dev =
     djangorestframework
     django-stubs
     djangorestframework-stubs
+    mypy<0.990
     flake8
     flake8-bugbear
     pre-commit

--- a/shell.nix
+++ b/shell.nix
@@ -31,7 +31,7 @@ devshell.mkShell {
     {
       help = "run tests";
       name = "app.test";
-      command = "pytest";
+      command = "pytest $@";
     }
     {
       help = "install dev deps";

--- a/src/extra_checks/checks/model_field_checks.py
+++ b/src/extra_checks/checks/model_field_checks.py
@@ -305,8 +305,10 @@ class CheckFieldChoicesConstraint(CheckModelField):
         choices = field.flatchoices  # type: ignore
         if choices:
             field_choices = [c[0] for c in choices]
-            if field.blank and "" not in field_choices:
+            if field.blank and "" not in field_choices and field.empty_strings_allowed:
                 field_choices.append("")
+            if field.null and None not in field_choices:
+                field_choices.append(None)
             in_name = f"{field.name}__in"
             for constraint in model._meta.constraints:
                 if isinstance(constraint, models.CheckConstraint):

--- a/src/extra_checks/checks/model_field_checks.py
+++ b/src/extra_checks/checks/model_field_checks.py
@@ -307,8 +307,6 @@ class CheckFieldChoicesConstraint(CheckModelField):
             field_choices = [c[0] for c in choices]
             if field.blank and "" not in field_choices and field.empty_strings_allowed:
                 field_choices.append("")
-            if field.null and None not in field_choices:
-                field_choices.append(None)
             in_name = f"{field.name}__in"
             for constraint in model._meta.constraints:
                 if isinstance(constraint, models.CheckConstraint):

--- a/src/extra_checks/checks/model_field_checks.py
+++ b/src/extra_checks/checks/model_field_checks.py
@@ -302,10 +302,10 @@ class CheckFieldChoicesConstraint(CheckModelField):
         ast: FieldASTProtocol,
         model: Type[models.Model],
     ) -> Iterator[django.core.checks.CheckMessage]:
-        choices = field.flatchoices  # type: ignore
+        choices = field.flatchoices
         if choices:
             field_choices = [c[0] for c in choices]
-            if field.blank and "" not in field_choices and field.empty_strings_allowed:
+            if field.empty_strings_allowed and field.blank and "" not in field_choices:
                 field_choices.append("")
             in_name = f"{field.name}__in"
             for constraint in model._meta.constraints:

--- a/tests/example/models.py
+++ b/tests/example/models.py
@@ -166,6 +166,8 @@ class ChoicesConstraint(models.Model):
     grouped = models.IntegerField(
         choices=[("g1", ((1, "1"), (2, "2"))), ("g2", ((3, "3"),))]
     )
+    integer_blank = models.IntegerField(choices=[(1, "One"), (2, "Two")], blank=True, null=True)
+    integer_blank_invalid = models.IntegerField(choices=[(1, "One"), (2, "Two")], blank=True, null=True)
 
     class Meta:
         constraints = [
@@ -183,6 +185,12 @@ class ChoicesConstraint(models.Model):
             ),
             models.CheckConstraint(
                 name="grouped_valid", check=models.Q(grouped__in=(1, 2, 3))
+            ),
+            models.CheckConstraint(
+                name="integer_blank", check=models.Q(integer_blank__in=(1, 2))
+            ),
+            models.CheckConstraint(
+                name="integer_blank_invalid", check=models.Q(integer_blank_invalid__in=(1, 2, ""))
             ),
         ]
 

--- a/tests/example/models.py
+++ b/tests/example/models.py
@@ -166,8 +166,12 @@ class ChoicesConstraint(models.Model):
     grouped = models.IntegerField(
         choices=[("g1", ((1, "1"), (2, "2"))), ("g2", ((3, "3"),))]
     )
-    integer_blank = models.IntegerField(choices=[(1, "One"), (2, "Two")], blank=True, null=True)
-    integer_blank_invalid = models.IntegerField(choices=[(1, "One"), (2, "Two")], blank=True, null=True)
+    integer_blank = models.IntegerField(
+        choices=[(1, "One"), (2, "Two")], blank=True, null=True
+    )
+    integer_blank_invalid = models.IntegerField(
+        choices=[(1, "One"), (2, "Two")], blank=True, null=True
+    )
 
     class Meta:
         constraints = [
@@ -190,7 +194,8 @@ class ChoicesConstraint(models.Model):
                 name="integer_blank", check=models.Q(integer_blank__in=(1, 2))
             ),
             models.CheckConstraint(
-                name="integer_blank_invalid", check=models.Q(integer_blank_invalid__in=(1, 2, ""))
+                name="integer_blank_invalid",
+                check=models.Q(integer_blank_invalid__in=(1, 2, "")),
             ),
         ]
 

--- a/tests/test_model_field_checks.py
+++ b/tests/test_model_field_checks.py
@@ -236,7 +236,13 @@ def test_field_choices_constraint(test_case):
         .run()
     )
     errors = {m.obj.name: m for m in messages}
-    assert errors.keys() == {"partial", "missed", "blank_missed", "blank_included", "integer_blank_invalid"}
+    assert errors.keys() == {
+        "partial",
+        "missed",
+        "blank_missed",
+        "blank_included",
+        "integer_blank_invalid",
+    }
     assert 'check=models.Q(partial__in=["S", "C"]))' in errors["partial"].hint
     assert "check=models.Q(missed__in=[1, 2]))" in errors["missed"].hint
     assert (
@@ -247,6 +253,6 @@ def test_field_choices_constraint(test_case):
         in errors["blank_included"].hint
     )
     assert (
-        'check=models.Q(integer_blank_invalid__in=[1, 2])'
+        "check=models.Q(integer_blank_invalid__in=[1, 2])"
         in errors["integer_blank_invalid"].hint
     )

--- a/tests/test_model_field_checks.py
+++ b/tests/test_model_field_checks.py
@@ -236,7 +236,7 @@ def test_field_choices_constraint(test_case):
         .run()
     )
     errors = {m.obj.name: m for m in messages}
-    assert errors.keys() == {"partial", "missed", "blank_missed", "blank_included"}
+    assert errors.keys() == {"partial", "missed", "blank_missed", "blank_included", "integer_blank_invalid"}
     assert 'check=models.Q(partial__in=["S", "C"]))' in errors["partial"].hint
     assert "check=models.Q(missed__in=[1, 2]))" in errors["missed"].hint
     assert (
@@ -245,4 +245,8 @@ def test_field_choices_constraint(test_case):
     assert (
         'check=models.Q(blank_included__in=["A", "B", ""])'
         in errors["blank_included"].hint
+    )
+    assert (
+        'check=models.Q(integer_blank_invalid__in=[1, 2])'
+        in errors["integer_blank_invalid"].hint
     )


### PR DESCRIPTION
Hello,

I've noticed that an empty string is expected in the choices of a constraint for X060.

Unfortunately, it is not checked if this field accepts "". For instance, None would be expected for nullable, blank IntegerFields. The "" also appear in suggestions, leading to broken, and inapplicable migrations on some DB engines.

I've made a quick fix, but maybe more logic is needed to fix this issues for more field types.

Thanks for the project and have a good day!