### PR TITLE
Change hint message for `field-choices-constraint`

### DIFF
--- a/src/extra_checks/checks/model_field_checks.py
+++ b/src/extra_checks/checks/model_field_checks.py
@@ -308,6 +308,6 @@ class CheckFieldChoicesConstraint(CheckModelField):
             check = f'models.Q({in_name}=[{", ".join([self._repr_choice(c) for c in field_choices])}])'
             yield self.message(
                 "Field with choices must have companion CheckConstraint to enforce choices on database level.",
-                hint=f'Add to Meta.constraints: `models.CheckConstraint(name="%(app_label)s_%(class)s_{field.name}_valid", check={check})`',
+                hint=f'Add to Meta.constraints: `models.CheckConstraint(name="%(app_label)s_%(class)s_{field.name}_valid", condition={check})`',
                 obj=field,
             )

--- a/src/extra_checks/checks/model_field_checks.py
+++ b/src/extra_checks/checks/model_field_checks.py
@@ -306,8 +306,9 @@ class CheckFieldChoicesConstraint(CheckModelField):
                         ):
                             return
             check = f'models.Q({in_name}=[{", ".join([self._repr_choice(c) for c in field_choices])}])'
+            arg_name = "condition" if django.VERSION >= (5, 1) else "check"
             yield self.message(
                 "Field with choices must have companion CheckConstraint to enforce choices on database level.",
-                hint=f'Add to Meta.constraints: `models.CheckConstraint(name="%(app_label)s_%(class)s_{field.name}_valid", condition={check})`',
+                hint=f'Add to Meta.constraints: `models.CheckConstraint(name="%(app_label)s_%(class)s_{field.name}_valid", {arg_name}={check})`',
                 obj=field,
             )

--- a/tests/test_model_field_checks.py
+++ b/tests/test_model_field_checks.py
@@ -244,7 +244,8 @@ def test_field_choices_constraint(test_case):
     assert 'condition=models.Q(partial__in=["S", "C"]))' in errors["partial"].hint
     assert "condition=models.Q(missed__in=[1, 2]))" in errors["missed"].hint
     assert (
-        'condition=models.Q(blank_missed__in=["A", "B", ""])' in errors["blank_missed"].hint
+        'condition=models.Q(blank_missed__in=["A", "B", ""])'
+        in errors["blank_missed"].hint
     )
     assert (
         'condition=models.Q(blank_included__in=["A", "B", ""])'

--- a/tests/test_model_field_checks.py
+++ b/tests/test_model_field_checks.py
@@ -241,17 +241,18 @@ def test_field_choices_constraint(test_case):
         "blank_included",
         "integer_blank_invalid",
     }
-    assert 'condition=models.Q(partial__in=["S", "C"]))' in errors["partial"].hint
-    assert "condition=models.Q(missed__in=[1, 2]))" in errors["missed"].hint
+    arg_name = "condition" if django.VERSION >= (5, 1) else "check"
+    assert f'{arg_name}=models.Q(partial__in=["S", "C"]))' in errors["partial"].hint
+    assert f"{arg_name}=models.Q(missed__in=[1, 2]))" in errors["missed"].hint
     assert (
-        'condition=models.Q(blank_missed__in=["A", "B", ""])'
+        f'{arg_name}=models.Q(blank_missed__in=["A", "B", ""])'
         in errors["blank_missed"].hint
     )
     assert (
-        'condition=models.Q(blank_included__in=["A", "B", ""])'
+        f'{arg_name}=models.Q(blank_included__in=["A", "B", ""])'
         in errors["blank_included"].hint
     )
     assert (
-        "condition=models.Q(integer_blank_invalid__in=[1, 2])"
+        f"{arg_name}=models.Q(integer_blank_invalid__in=[1, 2])"
         in errors["integer_blank_invalid"].hint
     )

--- a/tests/test_model_field_checks.py
+++ b/tests/test_model_field_checks.py
@@ -241,16 +241,16 @@ def test_field_choices_constraint(test_case):
         "blank_included",
         "integer_blank_invalid",
     }
-    assert 'check=models.Q(partial__in=["S", "C"]))' in errors["partial"].hint
-    assert "check=models.Q(missed__in=[1, 2]))" in errors["missed"].hint
+    assert 'condition=models.Q(partial__in=["S", "C"]))' in errors["partial"].hint
+    assert "condition=models.Q(missed__in=[1, 2]))" in errors["missed"].hint
     assert (
-        'check=models.Q(blank_missed__in=["A", "B", ""])' in errors["blank_missed"].hint
+        'condition=models.Q(blank_missed__in=["A", "B", ""])' in errors["blank_missed"].hint
     )
     assert (
-        'check=models.Q(blank_included__in=["A", "B", ""])'
+        'condition=models.Q(blank_included__in=["A", "B", ""])'
         in errors["blank_included"].hint
     )
     assert (
-        "check=models.Q(integer_blank_invalid__in=[1, 2])"
+        "condition=models.Q(integer_blank_invalid__in=[1, 2])"
         in errors["integer_blank_invalid"].hint
     )


### PR DESCRIPTION
`check=` was deprecated in Django5.1
See https://github.com/django/django/blob/55855bc6d0d2a270eb34952c578ee352389367ad/django/db/models/constraints.py#L165-L170