### PR TITLE
Fix: do not access `CheckConstraint.check` on django >=5.1

### DIFF
--- a/src/extra_checks/checks/model_field_checks.py
+++ b/src/extra_checks/checks/model_field_checks.py
@@ -295,10 +295,11 @@ class CheckFieldChoicesConstraint(CheckModelField):
                 field_choices.append("")
             in_name = f"{field.name}__in"
             for constraint in model._meta.constraints:
-                if isinstance(constraint, models.CheckConstraint) and isinstance(
-                    constraint.check, models.Q
-                ):
-                    for entry in constraint.check.children:
+                if isinstance(constraint, models.CheckConstraint):
+                    condition = constraint.check if django.VERSION < (5, 1) else constraint.condition
+                    if not isinstance(condition, models.Q):
+                        continue
+                    for entry in condition.children:
                         if (
                             isinstance(entry, tuple)
                             and entry[0] == in_name

--- a/src/extra_checks/checks/model_field_checks.py
+++ b/src/extra_checks/checks/model_field_checks.py
@@ -296,7 +296,11 @@ class CheckFieldChoicesConstraint(CheckModelField):
             in_name = f"{field.name}__in"
             for constraint in model._meta.constraints:
                 if isinstance(constraint, models.CheckConstraint):
-                    condition = constraint.check if django.VERSION < (5, 1) else constraint.condition
+                    condition = (
+                        constraint.check
+                        if django.VERSION < (5, 1)
+                        else constraint.condition
+                    )
                     if not isinstance(condition, models.Q):
                         continue
                     for entry in condition.children:


### PR DESCRIPTION
Follow up to https://github.com/kalekseev/django-extra-checks/pull/39